### PR TITLE
FEAT: Entry limiter for container id during switching

### DIFF
--- a/src/pages/ContainerSwitch.py
+++ b/src/pages/ContainerSwitch.py
@@ -131,7 +131,13 @@ class ContainerSwitch(Toplevel):
     def update_db(self):
 
         bg = "palegreen"
-        if len(self.old_reel_data) or not len(self.new_reel_data):
+        old_cont_input = self.cont_dict["old"]["entry"].get()
+        new_cont_input = self.cont_dict["new"]["entry"].get()
+
+        if len(old_cont_input) != 10 or len(new_cont_input) != 10:
+            text = f"Please scan Container ID to transfer."
+            bg = "tomato"
+        elif len(self.old_reel_data) or not len(self.new_reel_data):
             text = f"Please scan all reels to transfer."
             bg = "tomato"
             logger.info(text)

--- a/src/pages/ContainerSwitch.py
+++ b/src/pages/ContainerSwitch.py
@@ -140,13 +140,13 @@ class ContainerSwitch(Toplevel):
         elif len(self.old_reel_data) or not len(self.new_reel_data):
             text = f"Please scan all reels to transfer."
             bg = "tomato"
-            logger.info(text)
         else:
             try:
                 for reel_data in self.new_reel_data:
                     reel_id = reel_data.ReelID
                     reel_dict = reel_data.__dict__
-                    del reel_dict["ReelID"]
+                    if "ReelID" in reel_dict:
+                        del reel_dict["ReelID"]
                     update_reel_data(next(get_db()), reel_id, reel_dict)
             except Exception as e:
                 logger.error("Unable to update reel data in database", exc_info=True)
@@ -154,6 +154,7 @@ class ContainerSwitch(Toplevel):
 
             text = f"Update to new container completed. Please continue."
 
+        logger.info(text)
         self.info.config(text=text, bg=bg)
 
     def win_config(self):


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Container id during switching not check for length when button event.

## Solution / Fixes

added length check for both old and new container id

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
