### PR TITLE
BUG: fix msgbox below parent toplevel

### DIFF
--- a/src/components/messagebox/__init__.py
+++ b/src/components/messagebox/__init__.py
@@ -16,6 +16,7 @@ class CustomMessageBox(Toplevel):
         self.add_widgets(message)
         # To ensure window stays on top and focused
         self.grab_set()
+        self.focus_set()
         self.mainloop()
 
     def initialize(self, parent, mode: str):


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Custom messagebox is below parent toplevel.
Results in entry being able to be keyed causing the callback to fail when custom msgbox is released

## Solution / Fixes

added focus_set after grab_set on custom msgbox to prevent parent toplevel from being focused.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
