### PR TITLE
BUG: reel reset crashing program due to missing reference

### DIFF
--- a/src/pages/ContainerScan/utils/callback.py
+++ b/src/pages/ContainerScan/utils/callback.py
@@ -90,12 +90,11 @@ def handle_reelid_entry(parent, prompt: str, prompt_length: int) -> bool:
     if prompt_length > 15:
         return False
     if prompt_length == 15:
+        cont_full = run_reel_id(grandparent, prompt)
         # Clear and refocus reel ID
         clear_value(parent.widgets["Reelid"])
-        parent.widgets["Reelid"].focus()
-        if run_reel_id(grandparent, prompt):
+        if cont_full:
             # Clear and refocus container ID
             clear_value(parent.widgets["contid"])
-            parent.widgets["contid"].focus()
 
     return True


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

When reel entry causes an error, the reset was ran twice which causes the program to crash

## Solution / Fixes

Re-arrange the flow of the code ran to prevent double reset which causes the program to crash.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
