### PR TITLE
FEAT: add exit button for optcode popup during initialization

### DIFF
--- a/src/pages/OperatorCode/__init__.py
+++ b/src/pages/OperatorCode/__init__.py
@@ -1,5 +1,6 @@
 from tkinter import Toplevel
 
+from pages.OperatorCode.widgets.operator_code_buttons import OperatorCodeButtons
 from pages.OperatorCode.widgets.operator_code_info import OperatorCodeInfo
 from utils.tk_windows import terminate, window_size
 
@@ -32,11 +33,15 @@ class OperatorCode(Toplevel):
             f"{self.win_size['width']}x{self.win_size['height']}+{x_position}+{y_position}"
         )
         self.rowconfigure(0, weight=1)
-        self.rowconfigure(2, weight=1)
+        self.rowconfigure(3, weight=1)
         self.columnconfigure(0, weight=1)
-        self.columnconfigure(1, weight=10)
-        self.columnconfigure(2, weight=1)
+        self.columnconfigure(1, weight=7)
+        self.columnconfigure(2, weight=3)
+        self.columnconfigure(3, weight=1)
 
     def add_widgets(self):
         self.widgets["optcode_info"] = OperatorCodeInfo(self)
-        self.widgets["optcode_info"].grid(row=1, column=1)
+        self.widgets["optcode_info"].grid(row=1, column=1, columnspan=2)
+
+        self.widgets["optcode_buttons"] = OperatorCodeButtons(self)
+        self.widgets["optcode_buttons"].grid(row=2, column=2)

--- a/src/pages/OperatorCode/widgets/operator_code_buttons.py
+++ b/src/pages/OperatorCode/widgets/operator_code_buttons.py
@@ -1,0 +1,31 @@
+import sys
+from tkinter import EW, NS, RAISED
+from tkinter import Button, Frame
+
+from core.constants import font_size
+from utils.tk_windows import terminate
+
+
+class OperatorCodeButtons(Frame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.initialize(parent)
+        self.win_config()
+        self.add_widgets()
+
+    def initialize(self, parent):
+        self.parent = parent
+        self.widgets = {}
+
+    def win_config(self):
+        self.config(bg="#DDD")
+
+    def add_widgets(self):
+        Button(
+            self,
+            text="Close Program",
+            bg="firebrick2",
+            font=font_size["M"],
+            relief=RAISED,
+            command=lambda: sys.exit(),
+        ).grid(row=0, column=0, padx=10, pady=10, sticky=NS + EW)

--- a/src/pages/OperatorCode/widgets/operator_code_info.py
+++ b/src/pages/OperatorCode/widgets/operator_code_info.py
@@ -19,7 +19,7 @@ class OperatorCodeInfo(Frame):
     def win_config(self):
         self.config(bg="#DDD")
         self.columnconfigure(0, weight=1, uniform="a")
-        self.columnconfigure(3, weight=1, uniform="a")
+        self.columnconfigure(1, weight=1, uniform="a")
         self.rowconfigure(0, weight=1, uniform="a")
         self.rowconfigure(1, weight=1, uniform="a")
         self.reg_entry = (
@@ -36,11 +36,11 @@ class OperatorCodeInfo(Frame):
             fg="#CF352E",
             font=(*font_size["L"], "bold"),
             relief=RAISED,
-        ).grid(row=0, column=1, columnspan=2, pady=10, ipady=7, ipadx=5, sticky=EW)
+        ).grid(row=0, column=0, columnspan=2, pady=10, ipady=7, ipadx=5, sticky=EW)
 
         # MES ID
         Label(self, text="MES ID:", bg="#DDD", font=font_size["L"]).grid(
-            row=1, column=1
+            row=1, column=0
         )
         self.widgets["optcode"] = Entry(
             self,
@@ -49,6 +49,6 @@ class OperatorCodeInfo(Frame):
             validate="key",
             validatecommand=self.reg_entry,
         )
-        self.widgets["optcode"].grid(row=1, column=2, ipady=3, ipadx=20, pady=3)
+        self.widgets["optcode"].grid(row=1, column=1, ipady=3, ipadx=20, pady=3)
 
         self.widgets["optcode"].focus()


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

During initialization, if no operator code was inputted or if the input is not validated, the program cannot be closed due to the looping involved.

## Solution / Fixes

Add a exit button to exit without the need to key in operator code.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
