### PR TITLE
UI-UX: increase font size for custom msgbox info

### DIFF
--- a/src/components/messagebox/widgets/messagebox_content.py
+++ b/src/components/messagebox/widgets/messagebox_content.py
@@ -37,5 +37,5 @@ class CustomMessageBoxContent(Frame):
             text=message,
             wraplength=self.parent.win_size["width"] / 2,
             bg=self.parent.msgbox_mode["bg_color"],
-            font=font_size["L"],
+            font=font_size["XL"],
         ).grid(row=1, column=3, sticky=EW)


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Custom msgbox info font size slightly small and hard to read.

## Solution / Fixes

Increase the font size by one tier up. from M to L.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [X] UI/UX improvement
