### PR TITLE
FEAT: add error check for lot and cont entry

### DIFF
--- a/src/pages/ContainerScan/utils/callback.py
+++ b/src/pages/ContainerScan/utils/callback.py
@@ -73,6 +73,9 @@ def handle_contid_entry(parent, prompt: str, prompt_length: int) -> bool:
 
     grandparent = parent.parent
 
+    if grandparent.cache["lotNo"].get() == "":
+        raise ValueError("Please Scan Lot No First")
+
     if prompt_length > 10:
         return False
     if prompt_length == 10:
@@ -86,6 +89,8 @@ def handle_reelid_entry(parent, prompt: str, prompt_length: int) -> bool:
     """Handles the reel ID input, including validations and refreshing the container widget."""
 
     grandparent = parent.parent
+    if grandparent.cache["contid"].get() == "":
+        raise ValueError("Please Scan Container ID First")
 
     if prompt_length > 15:
         return False


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

Scanning cont id and reel id will not raise error or prevent it from continuing when lot no and cont id does not exists

## Solution / Fixes

add error check on cont id and reel id entry to prevent continuation

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
