### PR TITLE
BUG: missing key reels_id as it is instantiate in earlier function

### DIFF
--- a/src/pages/ContainerScan/utils/casing.py
+++ b/src/pages/ContainerScan/utils/casing.py
@@ -64,7 +64,7 @@ def run_reel_id(root, reel_input: str) -> None:
 
     lot_no = root.cache["lotNo"].get()
     cont_id = root.cache["contid"].get()
-    reel_ids = root.reel_ids
+    reel_ids = root.get("reel_ids", [])
 
     # Check if reel_input in reel_ids from server
     if reel_input not in reel_ids:


### PR DESCRIPTION
## Previous Context

resolves #0000

## Description

> Please provide a detailed or a short description of the issues

scanning reels entry before lot no entry causes error
error due to key not instantiated

## Solution / Fixes

check if key exists, if not return blank list

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Hotfix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement
